### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/runtingt/CondorTools/security/code-scanning/2](https://github.com/runtingt/CondorTools/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/ci.yaml`. The block can be added at the top level (applies to all jobs) or at the job level (for more granular control). Since both jobs (`lint-and-format` and `pytest`) do not require write access to repository contents, the minimal required permission is `contents: read`. The Codecov upload step may require additional permissions, but according to Codecov documentation, `contents: read` is sufficient for uploading coverage reports. Therefore, the best fix is to add a top-level `permissions` block with `contents: read` to the workflow file, immediately after the `name` field and before the `on` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
